### PR TITLE
Fix Parameter name mix-up in HttpResponse

### DIFF
--- a/uhttpsharp/HttpResponse.cs
+++ b/uhttpsharp/HttpResponse.cs
@@ -160,18 +160,18 @@ namespace uhttpsharp
         private readonly IHttpHeaders _headers;
         private readonly HttpResponseCode _responseCode;
 
-        public HttpResponse(HttpResponseCode code, string content, bool closeConnection)
-            : this(code, "text/html; charset=utf-8", StringToStream(content), closeConnection)
+        public HttpResponse(HttpResponseCode code, string content, bool keepAliveConnection)
+            : this(code, "text/html; charset=utf-8", StringToStream(content), keepAliveConnection)
         {
         }
 
-        public HttpResponse(HttpResponseCode code, string content, IEnumerable<KeyValuePair<string,string>> headers, bool closeConnection)
-            : this(code, "text/html; charset=utf-8", StringToStream(content), closeConnection,headers)
+        public HttpResponse(HttpResponseCode code, string content, IEnumerable<KeyValuePair<string,string>> headers, bool keepAliveConnection)
+            : this(code, "text/html; charset=utf-8", StringToStream(content), keepAliveConnection, headers)
         {
         }
 
-        public HttpResponse(string contentType, Stream contentStream, bool closeConnection)
-            : this(HttpResponseCode.Ok, contentType, contentStream, closeConnection)
+        public HttpResponse(string contentType, Stream contentStream, bool keepAliveConnection)
+            : this(HttpResponseCode.Ok, contentType, contentStream, keepAliveConnection)
         {
         }
 


### PR DESCRIPTION
The parameter _closeConnection_ in different ctor overloads of _HttpResponse_ should be named _keepAliveConnection_ instead: It gets negated when stored in private field __closeConnection_ (c.f. line 188).

Strictly speaking, this PR introduces a breaking change (for callers who use named arguments). However, it should not effect many consumers. The alternative to keep the name of the parameter but change its behavior accordingly would be less compatible for existing code bases.
